### PR TITLE
add xdr argument

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2024-05-10  Travers Ching  <traversc@gmail.com>
+
+	* src/serialize.cpp (serializeToRaw): Add xdr argument, 
+	set to false to use binary format instead
+	* inst/include/RApiSerializeAPI.h (serializeToRaw): Idem
+
 2024-02-23  Dirk Eddelbuettel  <edd@debian.org>
 
 	* .github/workflows/ci.yaml (jobs): Update to actions/checkout@v4,

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2024-05-11  Dirk Eddelbuettel  <edd@debian.org>
+
+	* R/serialization.R (serializeToRaw): Add an xdr=TRUE argument
+	* man/RApiSerialize-package.Rd: Document it
+	* tests/simpleTests.R: Add simple tests for xdr feature
+	* tests/simpleTests.Rout.save: Idem
+
 2024-05-10  Travers Ching  <traversc@gmail.com>
 
 	* src/serialize.cpp (serializeToRaw): Add xdr argument, 

--- a/ChangeLog
+++ b/ChangeLog
@@ -5,9 +5,12 @@
 	* tests/simpleTests.R: Add simple tests for xdr feature
 	* tests/simpleTests.Rout.save: Idem
 
+	* src/serialize.cpp: Define R_NO_REMAP, switch to Rf_error and
+	Rf_allocVector
+
 2024-05-10  Travers Ching  <traversc@gmail.com>
 
-	* src/serialize.cpp (serializeToRaw): Add xdr argument, 
+	* src/serialize.cpp (serializeToRaw): Add xdr argument,
 	set to false to use binary format instead
 	* inst/include/RApiSerializeAPI.h (serializeToRaw): Idem
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: RApiSerialize
 Type: Package
 Title: R API Serialization 
-Version: 0.1.2
-Date: 2022-08-25
+Version: 0.1.3
+Date: 2024-05-10
 Author: Dirk Eddelbuettel, Ei-ji Nakama, Junji Nakano, and R Core (original code)
 Maintainer: Dirk Eddelbuettel <edd@debian.org>
 Description: Access to the internal R serialization code is provided for

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: RApiSerialize
 Type: Package
 Title: R API Serialization 
-Version: 0.1.3
+Version: 0.1.2.1
 Date: 2024-05-10
 Author: Dirk Eddelbuettel, Ei-ji Nakama, Junji Nakano, and R Core (original code)
 Maintainer: Dirk Eddelbuettel <edd@debian.org>

--- a/R/serialization.R
+++ b/R/serialization.R
@@ -19,7 +19,7 @@
 ##  along with RApiSerialize.  If not, see <http://www.gnu.org/licenses/>.
 
 serializeToRaw <- function(obj, version=2, xdr=TRUE) {
-    .Call(C_serializeToRaw, obj, version)
+    .Call(C_serializeToRaw, obj, version, xdr)
 }
 
 unserializeFromRaw <- function(obj) {

--- a/R/serialization.R
+++ b/R/serialization.R
@@ -1,7 +1,7 @@
 
 ##  RApiSerialize -- Packge to provide Serialization as in the R API
 ##
-##  Copyright (C) 2014 - 2022  Dirk Eddelbuettel
+##  Copyright (C) 2014 - 2024  Dirk Eddelbuettel
 ##
 ##  This file is part of RApiSerialize.
 ##
@@ -18,7 +18,7 @@
 ##  You should have received a copy of the GNU General Public License
 ##  along with RApiSerialize.  If not, see <http://www.gnu.org/licenses/>.
 
-serializeToRaw <- function(obj, version=2) {
+serializeToRaw <- function(obj, version=2, xdr=TRUE) {
     .Call(C_serializeToRaw, obj, version)
 }
 

--- a/inst/include/RApiSerializeAPI.h
+++ b/inst/include/RApiSerializeAPI.h
@@ -47,7 +47,8 @@ extern "C" {
 /* provided the interface for the function exported 	*/
 /* in ../src/init.c via R_RegisterCCallable()		*/
 
-SEXP attribute_hidden serializeToRaw(SEXP x, SEXP ver = R_NilValue) {
+SEXP attribute_hidden serializeToRaw(SEXP x, SEXP ver = R_NilValue,
+                                     SEXP use_xdrSexp = R_NilValue) {
     static SEXP(*fun)(SEXP, SEXP) =
         (SEXP(*)(SEXP,SEXP)) R_GetCCallable("RApiSerialize", "serializeToRaw");
     return fun(x, ver);

--- a/inst/include/RApiSerializeAPI.h
+++ b/inst/include/RApiSerializeAPI.h
@@ -1,8 +1,7 @@
-/* -*- mode: C; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*- */
 /*
  *  RApiSerialize -- Packge to provide Serialization as in the R API 
  *
- *  Copyright (C) 2014  Dirk Eddelbuettel 
+ *  Copyright (C) 2014-2024  Dirk Eddelbuettel
  *
  *  This file is part of RApiSerialize.
  *

--- a/man/RApiSerialize-package.Rd
+++ b/man/RApiSerialize-package.Rd
@@ -16,12 +16,16 @@
   provided at the R level.
 }
 \usage{
-  serializeToRaw(obj, version=2)
+  serializeToRaw(obj, version=2, xdr=TRUE)
   unserializeFromRaw(obj)
 }
 \arguments{
   \item{obj}{An R object which is going to (un)serialized by the corresponding function.}
-  \item{version}{An integer selection the R serialization format. Default is 2, and values 2 or 3 are currently supported.}
+  \item{version}{An integer selection the R serialization format. Default is
+  2, and values 2 or 3 are currently supported.}
+  \item{xdr}{A logical value selection (portable) XDR encoding which is the
+  default. Use \code{FALSE} for speed-up suitable for common little-endian
+  system at a loss of portability.}
 }
 \details{
   The C code in this package is taken from R source code, where it

--- a/src/init.c
+++ b/src/init.c
@@ -1,8 +1,7 @@
-/* -*- mode: C; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*- */
 /*
  *  RApiSerialize -- Packge to provide Serialization as in the R API 
  *
- *  Copyright (C) 2014 - 2022  Dirk Eddelbuettel
+ *  Copyright (C) 2014 - 2024  Dirk Eddelbuettel
  *
  *  This file is part of RApiSerialize.
  *
@@ -27,13 +26,13 @@
 
 /*  function declarations -- could be in external header file if used  */
 /*  by functions in anotherfile in this package                        */
-SEXP serializeToRaw(SEXP object, SEXP versionSexp);
+SEXP serializeToRaw(SEXP object, SEXP versionSexp, SEXP useXdrSexp);
 SEXP unserializeFromRaw(SEXP object);
 
 
 /* definition of functions provided for .Call() 			*/
 static const R_CallMethodDef callMethods[] = {
-    { "serializeToRaw",    	(DL_FUNC) &serializeToRaw,          2 },
+    { "serializeToRaw",    	(DL_FUNC) &serializeToRaw,          3 },
     { "unserializeFromRaw",  	(DL_FUNC) &unserializeFromRaw,      1 },
     { NULL,                	NULL,                               0 }
 };

--- a/src/serialize.cpp
+++ b/src/serialize.cpp
@@ -197,7 +197,8 @@ static SEXP CloseMemOutPStream(R_outpstream_t stream)
 
 /** ---- **/
 
-extern "C" SEXP serializeToRaw(SEXP object, SEXP versionSexp = R_NilValue) {
+extern "C" SEXP serializeToRaw(SEXP object, SEXP versionSexp = R_NilValue,
+                               SEXP use_xdrSexp = R_NilValue) {
     struct R_outpstream_st out;
     R_pstream_format_t type;
     int version;
@@ -210,13 +211,23 @@ extern "C" SEXP serializeToRaw(SEXP object, SEXP versionSexp = R_NilValue) {
       version = Rf_asInteger(versionSexp);
     }
     if (version == NA_INTEGER || version <= 0) {
-	Rf_error("bad version value");
+      Rf_error("bad version value");
     }
-
+    
+    
     //type = R_pstream_binary_format;
     //type = R_pstream_ascii_format;
-    type = R_pstream_xdr_format;
-    
+    //type = R_pstream_xdr_format;
+    if(use_xdrSexp == R_NilValue) {
+      type = R_pstream_xdr_format;
+    } else {
+      int use_xdr = Rf_asLogical(use_xdrSexp);
+      if(use_xdr) {
+        type = R_pstream_xdr_format;
+      } else {
+        type = R_pstream_binary_format;
+      }
+    }
 
     /* set up a context which will free the buffer if there is an error */
     

--- a/src/serialize.cpp
+++ b/src/serialize.cpp
@@ -63,6 +63,11 @@
 
 #include <stdlib.h>
 #include <string.h>
+
+#ifndef R_NO_REMAP
+ #define R_NO_REMAP
+#endif
+
 // does not seem to be needed #define USE_INTERNAL
 #include <Rinternals.h>
 
@@ -85,7 +90,7 @@ typedef struct membuf_st {
 static void resize_buffer(membuf_t mb, R_xlen_t needed) {
     unsigned char *tmp;
     if (needed > R_XLEN_T_MAX)
-	error("serialization is too large to store in a raw vector");
+	Rf_error("serialization is too large to store in a raw vector");
     #ifdef LONG_VECTOR_SUPPORT
         if(needed < 10000000) /* ca 10MB */
             needed = (1+2*needed/INCR) * INCR;
@@ -102,7 +107,7 @@ static void resize_buffer(membuf_t mb, R_xlen_t needed) {
     tmp = (unsigned char*) realloc((void*) mb->buf, (size_t) needed);
     if (tmp == NULL) {
 	free(mb->buf); mb->buf = NULL;
-	error("cannot allocate buffer");
+	Rf_error("cannot allocate buffer");
     } else mb->buf = tmp;
     mb->size = needed;
 }
@@ -122,7 +127,7 @@ static void OutBytesMem(R_outpstream_t stream, void *buf, int length)
     #ifndef LONG_VECTOR_SUPPORT
         /* There is a potential overflow here on 32-bit systems */
         if ((double) mb->count + length > (double) INT_MAX)
-            error("serialization is too large to store in a raw vector");
+            Rf_error("serialization is too large to store in a raw vector");
     #endif
     if (needed > mb->size) resize_buffer(mb, needed);
     memcpy(mb->buf + mb->count, buf, length);
@@ -133,7 +138,7 @@ static int InCharMem(R_inpstream_t stream)
 {
     membuf_t mb = (membuf_t) stream->data;
     if (mb->count >= mb->size)
-	error("read error");
+	Rf_error("read error");
     return mb->buf[mb->count++];
 }
 
@@ -141,7 +146,7 @@ static void InBytesMem(R_inpstream_t stream, void *buf, int length)
 {
     membuf_t mb = (membuf_t) stream->data;
     if (mb->count + (R_xlen_t) length > mb->size)
-	error("read error");
+	Rf_error("read error");
     memcpy(buf, mb->buf + mb->count, length);
     mb->count += length;
 }
@@ -185,9 +190,9 @@ static SEXP CloseMemOutPStream(R_outpstream_t stream)
     /* duplicate check, for future proofing */
 #ifndef LONG_VECTOR_SUPPORT
     if(mb->count > INT_MAX)
-	error("serialization is too large to store in a raw vector");
+	Rf_error("serialization is too large to store in a raw vector");
 #endif
-    PROTECT(val = allocVector(RAWSXP, mb->count));
+    PROTECT(val = Rf_allocVector(RAWSXP, mb->count));
     memcpy(RAW(val), mb->buf, mb->count);
     free_mem_buffer(mb);
     UNPROTECT(1);
@@ -197,7 +202,7 @@ static SEXP CloseMemOutPStream(R_outpstream_t stream)
 /** ---- **/
 
 extern "C" SEXP serializeToRaw(SEXP object, SEXP versionSexp = R_NilValue,
-                               SEXP use_xdrSexp = R_NilValue) {
+                               SEXP useXdrSexp = R_NilValue) {
     struct R_outpstream_st out;
     R_pstream_format_t type;
     int version;
@@ -217,10 +222,10 @@ extern "C" SEXP serializeToRaw(SEXP object, SEXP versionSexp = R_NilValue,
     //type = R_pstream_binary_format;
     //type = R_pstream_ascii_format;
     //type = R_pstream_xdr_format;
-    if (use_xdrSexp == R_NilValue) {
+    if (useXdrSexp == R_NilValue) {
         type = R_pstream_xdr_format;
     } else {
-        int use_xdr = Rf_asLogical(use_xdrSexp);
+        int use_xdr = Rf_asLogical(useXdrSexp);
         if (use_xdr) {
             type = R_pstream_xdr_format;
         } else {
@@ -254,7 +259,7 @@ extern "C" SEXP unserializeFromRaw(SEXP object) {
         InitMemInPStream(&in, &mbs, data,  length, NULL, NULL);
         return R_Unserialize(&in);
     }
-    error("can't unserialize object");
+    Rf_error("can't unserialize object");
     return(R_UnboundValue);
 }
 

--- a/src/serialize.cpp
+++ b/src/serialize.cpp
@@ -1,8 +1,7 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
 //  RApiSerialize -- Packge to provide Serialization as in the R API 
 //
-//  Copyright (C) 2014 - 2022  Dirk Eddelbuettel
+//  Copyright (C) 2014 - 2024  Dirk Eddelbuettel
 //  Copyright (C) 2013 - 2014  Ei-ji Nakama and Junji Nakano
 //  Copyright (C) 1995 - 2013  The R Core Team
 //
@@ -206,27 +205,27 @@ extern "C" SEXP serializeToRaw(SEXP object, SEXP versionSexp = R_NilValue,
     SEXP val;
 
     if (versionSexp == R_NilValue) {
-      version = R_DefaultSerializeVersion;
+        version = R_DefaultSerializeVersion;
     } else {
-      version = Rf_asInteger(versionSexp);
+        version = Rf_asInteger(versionSexp);
     }
     if (version == NA_INTEGER || version <= 0) {
-      Rf_error("bad version value");
+        Rf_error("bad version value");
     }
     
     
     //type = R_pstream_binary_format;
     //type = R_pstream_ascii_format;
     //type = R_pstream_xdr_format;
-    if(use_xdrSexp == R_NilValue) {
-      type = R_pstream_xdr_format;
-    } else {
-      int use_xdr = Rf_asLogical(use_xdrSexp);
-      if(use_xdr) {
+    if (use_xdrSexp == R_NilValue) {
         type = R_pstream_xdr_format;
-      } else {
-        type = R_pstream_binary_format;
-      }
+    } else {
+        int use_xdr = Rf_asLogical(use_xdrSexp);
+        if (use_xdr) {
+            type = R_pstream_xdr_format;
+        } else {
+            type = R_pstream_binary_format;
+        }
     }
 
     /* set up a context which will free the buffer if there is an error */

--- a/tests/simpleTests.R
+++ b/tests/simpleTests.R
@@ -16,3 +16,8 @@ identical(unserializeFromRaw(serializeToRaw(fit,3)), fit)
 identical(unserializeFromRaw(serialize(fit, NULL)), fit)
 ## R's serialize and R's unserialize (doh)
 identical(unserialize(serialize(fit, NULL)), fit)
+## serialize and use our unserialize, no xdr
+identical(unserializeFromRaw(serializeToRaw(fit,2,TRUE)), fit)
+identical(unserializeFromRaw(serializeToRaw(fit,3,TRUE)), fit)
+identical(unserializeFromRaw(serializeToRaw(fit,2,FALSE)), fit)
+identical(unserializeFromRaw(serializeToRaw(fit,3,FALSE)), fit)

--- a/tests/simpleTests.Rout.save
+++ b/tests/simpleTests.Rout.save
@@ -1,7 +1,7 @@
 
-R version 4.2.1 (2022-06-23) -- "Funny-Looking Kid"
-Copyright (C) 2022 The R Foundation for Statistical Computing
-Platform: x86_64-pc-linux-gnu (64-bit)
+R version 4.4.0 (2024-04-24) -- "Puppy Cup"
+Copyright (C) 2024 The R Foundation for Statistical Computing
+Platform: x86_64-pc-linux-gnu
 
 R is free software and comes with ABSOLUTELY NO WARRANTY.
 You are welcome to redistribute it under certain conditions.
@@ -41,7 +41,16 @@ Type 'q()' to quit R.
 > ## R's serialize and R's unserialize (doh)
 > identical(unserialize(serialize(fit, NULL)), fit)
 [1] TRUE
+> ## serialize and use our unserialize, no xdr
+> identical(unserializeFromRaw(serializeToRaw(fit,2,TRUE)), fit)
+[1] TRUE
+> identical(unserializeFromRaw(serializeToRaw(fit,3,TRUE)), fit)
+[1] TRUE
+> identical(unserializeFromRaw(serializeToRaw(fit,2,FALSE)), fit)
+[1] TRUE
+> identical(unserializeFromRaw(serializeToRaw(fit,3,FALSE)), fit)
+[1] TRUE
 > 
 > proc.time()
    user  system elapsed 
-  0.143   0.015   0.151 
+  0.355   0.481   0.174 


### PR DESCRIPTION
Hi Dirk, what do you think about adding an argument for choosing between XDR and binary formats? From my testing serialization using binary fromat is about 3.5x faster. 

Comparison
```
library(Rcpp)
sourceCpp(code="#include <Rcpp.h>
#include "RApiSerializeAPI.h"
// [[Rcpp::depends(RApiSerialize)]]
// [[Rcpp::export(rng=false)]]
SEXP rapi_serializeToRaw(SEXP x, SEXP use_xdrSexp) {
  return serializeToRaw(x, R_NilValue, use_xdrSexp);
}
// [[Rcpp::export(rng=false)]]
SEXP rapi_unserializeFromRaw(SEXP x) {
  return unserializeFromRaw(x);
}")

x <- 1:1e8/2
system.time(out1 <- rapi_serializeToRaw(x, TRUE)) # use XDR
# user  system elapsed
# 0.608   0.069   0.676
system.time(out2 <- rapi_serializeToRaw(x, FALSE)) # use Binary
# user  system elapsed
# 0.104   0.081   0.186

system.time(y1 <- rapi_unserializeFromRaw(out1)) # use XDR
# user  system elapsed
# 0.508   0.051   0.558
system.time(y2 <- rapi_unserializeFromRaw(out2)) # use Binary
# user  system elapsed
# 0.507   0.050   0.557

identical(y1, y2) # TRUE
```